### PR TITLE
Update docs based on Raygun.Aspire.Hosting.Raygun renaming

### DIFF
--- a/CHANGE-LOG.md
+++ b/CHANGE-LOG.md
@@ -1,7 +1,7 @@
 # Change Log for Raygun4Aspire
 
 ### v2.0.0
-- Breaking change - The Raygun App component has been split out into a separate [Aspire.Hosting.Raygun NuGet package](https://www.nuget.org/packages/Aspire.Hosting.Raygun). If you were using a previous version, uninstall the `Raygun4Aspire` NuGet package **from just the AppHost project** and replace it with the new `Aspire.Hosting.Raygun` NuGet package. You'll also no longer need the `Raygun4Aspire` using statement in the AppHost `Program.cs`.
+- Breaking change - The Raygun App component has been split out into a separate [Raygun.Aspire.Hosting.Raygun NuGet package](https://www.nuget.org/packages/Raygun.Aspire.Hosting.Raygun). If you were using a previous version, uninstall the `Raygun4Aspire` NuGet package **from just the AppHost project** and replace it with the new `Raygun.Aspire.Hosting.Raygun` NuGet package. You'll also no longer need the `Raygun4Aspire` using statement in the AppHost `Program.cs`.
 - The Raygun App component (that was moved to a different package as mentioned above) now has AI Error Resolution! See the README for more details.
 
 ### v1.0.1

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@
 
 # Installation
 
-## Step 1 - Install the Aspire.Hosting.Raygun NuGet package
+## Step 1 - Install the Raygun.Aspire.Hosting.Raygun NuGet package
 
-Install the [Aspire.Hosting.Raygun NuGet package](https://www.nuget.org/packages/Aspire.Hosting.Raygun) into your **Aspire orchestration project (AppHost)**. Either use the NuGet package management GUI in the IDE you use, OR use the below dotnet command.
+Install the [Raygun.Aspire.Hosting.Raygun NuGet package](https://www.nuget.org/packages/Raygun.Aspire.Hosting.Raygun) into your **Aspire orchestration project (AppHost)**. Either use the NuGet package management GUI in the IDE you use, OR use the below dotnet command.
 
 ```bash
-dotnet add package Aspire.Hosting.Raygun
+dotnet add package Raygun.Aspire.Hosting.Raygun
 ```
 
 ## Step 2 - Add Raygun to the orchestration builder


### PR DESCRIPTION
Aspire.Hosting of course is a reserved prefix in NuGet, so I've renamed Aspire.Hosting.Raygun to Raygun.Aspire.Hosting.Raygun which impacts the documentation in this Raygun4Aspire package.